### PR TITLE
Refactor `ragnar_find_links`

### DIFF
--- a/R/read-html.R
+++ b/R/read-html.R
@@ -347,7 +347,7 @@ ragnar_find_links <- function(x, depth = 0L, children_only = TRUE, progress = TR
   }
 
   deque <- reticulate::import("collections")$deque()
-  visited <- reticulate::py_eval("set()")
+  visited <- reticulate::import_builtins()$set()
   problems <- list()
 
   deque$append(list(url = xml_url2(x), depth = 0))


### PR DESCRIPTION
This removes the recursion and uses Python data structures instead of growing vectors.
It's not necessarily faster, but allows us to better keep track of the current state.
The progress bar now reports how many links were currently found, as well as how many are still on the queue to be visited.