### PR TITLE
Retrieve metadata

### DIFF
--- a/R/store.R
+++ b/R/store.R
@@ -194,6 +194,7 @@ ragnar_store_connect <- function(location = ":memory:",
   if (!all(c("chunks", "metadata") %in% dbListTables(con))) {
     stop("Store must be created with ragnar_store_create()")
   }
+  dbExecute(con, "INSTALL fts; INSTALL vss;")
   dbExecute(con, "LOAD fts; LOAD vss;")
 
   metadata <- dbReadTable(con, "metadata")


### PR DESCRIPTION
This PR does two small unrelated things:

- `retrieve_*` functions now return the additional metadata that's available in the store.
- Fixes a deployment bug. It's possible that the duckdb installation in the machine we deployed to doesn't have the extensions installed, so we call install when connecting to a store. This seems to be a no-op when they are already installed.

