### PR TITLE
Add a name for stores to use

### DIFF
--- a/R/ellmer.R
+++ b/R/ellmer.R
@@ -29,7 +29,7 @@ function(chat, store, store_description = "the knowledge store", ...) {
 
   chat$register_tool(
     ellmer::tool(
-      .name = "rag_retrieve_from_knowledge_store",
+      .name = glue::glue("rag_retrieve_from_{store@name}"),
       function(text) {
         ragnar_retrieve(store, text, ...)$text |>
           stringi::stri_flatten("\n\n---\n\n")

--- a/R/embed-bedrock.R
+++ b/R/embed-bedrock.R
@@ -1,6 +1,6 @@
 
 #' Embed text using a Bedrock model
-#' 
+#'
 #' @inheritParams embed_ollama
 #' @inheritParams ellmer::chat_bedrock
 #' @param model Currently only Cohere.ai and Amazon Titan models are supported.
@@ -9,15 +9,15 @@
 #'   You may look for available models in the Bedrock Model Catalog
 #' @param api_args Additional arguments to pass to the Bedrock API. Dependending
 #'   on the `model`, you might be able to provide different parameters. Check
-#'   the documentation for the model you are using in the 
+#'   the documentation for the model you are using in the
 #'   [Bedrock user guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html).
-#' 
+#'
 #' @seealso [embed_ollama()]
-#' 
-#' @returns 
-#' If `x` is missing returns a function that can be called to get embeddings. 
+#'
+#' @returns
+#' If `x` is missing returns a function that can be called to get embeddings.
 #' If `x` is not missing, a matrix of embeddings with 1 row per input string, or a dataframe with an 'embedding' column.
-#' 
+#'
 #' @export
 embed_bedrock <- function(x, model, profile, api_args = list()) {
 
@@ -99,14 +99,14 @@ embed_bedrock_cohere <- function(base_req, inputs, api_args, req_auth_bedrock) {
 
   out <- list()
   for (indices in chunk_list(seq_along(inputs), 20)) {
-    
+
     body <- rlang::list2(
       texts = as.list(inputs[indices]),
       !!!api_args
     )
-    
-    resp <- base_req |> 
-      httr2::req_body_json(body) |> 
+
+    resp <- base_req |>
+      httr2::req_body_json(body) |>
       req_auth_bedrock() |>
       httr2::req_perform()
 
@@ -131,15 +131,15 @@ embed_bedrock_titan <- function(base_req, inputs, api_args, req_auth_bedrock) {
       inputText = input,
       !!!api_args
     )
-    
-    resp <- base_req |> 
-      httr2::req_body_json(body) |> 
+
+    resp <- base_req |>
+      httr2::req_body_json(body) |>
       req_auth_bedrock() |>
       httr2::req_perform()
 
     httr2::resp_body_json(resp)$embedding
   })
-    
+
   matrix(unlist(out), nrow = length(inputs), ncol = length(out[[1]]), byrow = TRUE)
 }
 
@@ -180,6 +180,7 @@ aws_creds_cache <- function(profile) {
 
 the <- rlang::new_environment()
 the$credentials_cache <- rlang::new_environment()
+the$current_store_id <- NULL
 
 credentials_cache <- function(key) {
   list(

--- a/man/ragnar_store_create.Rd
+++ b/man/ragnar_store_create.Rd
@@ -10,7 +10,8 @@ ragnar_store_create(
   embedding_size = ncol(embed("foo")),
   overwrite = FALSE,
   ...,
-  extra_cols = NULL
+  extra_cols = NULL,
+  name = NULL
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ should be added to the store. Such columns can be used for adding additional
 context when retrieving. See the examples for more information.
 \code{\link[vctrs:vec_cast]{vctrs::vec_cast()}} is used to consistently perform type checks and casts
 when inserting with \code{\link[=ragnar_store_insert]{ragnar_store_insert()}}.}
+
+\item{name}{A unique name for the store. Must match the \verb{^[a-zA-Z0-9_-]+$}
+regex. Used by \code{\link[=ragnar_register_tool_retrieve]{ragnar_register_tool_retrieve()}} for registering tools.}
 }
 \value{
 a \code{DuckDBRagnarStore} object

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1,6 +1,6 @@
 test_that("ragnar_store_update/insert", {
   store <- ragnar_store_create(embed = \(x) matrix(nrow = length(x), ncol = 100, stats::runif(100)))
-  expect_equal(store@name, "store_001")
+  expect_true(grepl("^store_[0-9]+$", store@name))
 
   chunks <- data.frame(
     origin = "foo",

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1,5 +1,6 @@
 test_that("ragnar_store_update/insert", {
   store <- ragnar_store_create(embed = \(x) matrix(nrow = length(x), ncol = 100, stats::runif(100)))
+  expect_equal(store@name, "store_001")
 
   chunks <- data.frame(
     origin = "foo",


### PR DESCRIPTION
Stores now be named and the names is re-used when registering the store for tool calling.
This allows users to register multiple stores into the same chat.

(Sorry for the whitespace noise) 